### PR TITLE
Fixing docstring for enumerations

### DIFF
--- a/syntaxes/modelica.tmGrammar.yaml
+++ b/syntaxes/modelica.tmGrammar.yaml
@@ -57,7 +57,7 @@ patterns:
       2:
         name: entity.name.type
       3:
-        name: string.quoted.double
+        name: comment.line
   - match: ((function)\s+\w+\s*(".*")*)
     captures:
       1:
@@ -73,10 +73,10 @@ patterns:
     name: string.quoted.double
     patterns:
       - include: "#escapes"
-  - match: '["\w\)\]](\s+".*"\s*);'
+  - match: '["\w\)\]](\s+"[^"]*"\s*);'
     captures:
       1:
-        name: string.quoted.double
+        name: comment.line
 
 repository:
   escapes:


### PR DESCRIPTION
  - Use comment.line for doc strings everywhere