### PR TITLE
Add `class` keyword to Class Types

### DIFF
--- a/syntaxes/metamodelica.tmGrammar.yaml
+++ b/syntaxes/metamodelica.tmGrammar.yaml
@@ -88,7 +88,7 @@ patterns:
     name: support.type
 
   # Class Type
-  - begin: \b(record|type|package|function|uniontype)\s+(\w+)\s*("([^"]|\\")*(?<!\\)")?
+  - begin: \b(class|record|type|package|function|uniontype)\s+(\w+)\s*("([^"]|\\")*(?<!\\)")?
     beginCaptures:
       1:
         name: keyword


### PR DESCRIPTION
The class keyword was forgotten. This commit adds it to the possible class types. This class type is mostly used to extend ExternalObject.