### PR TITLE
Fix scope of Option literals

### DIFF
--- a/syntaxes/metamodelica.tmGrammar.yaml
+++ b/syntaxes/metamodelica.tmGrammar.yaml
@@ -106,7 +106,7 @@ patterns:
       - include: "source.metamodelica"
 
   # Option literals
-  - match: (SOME\(.*\)|NONE\(\))
+  - match: (SOME\(|NONE\(\))
     name: entity.name.type
 
   # Function calls

--- a/test/metamodelica/Option.test.mo
+++ b/test/metamodelica/Option.test.mo
@@ -1,14 +1,6 @@
 // SYNTAX TEST "source.metamodelica" "Option"
 
-function f
-  input Option<Integer> oi;
-//      ^^^^^^ source.metamodelica storage.type
-//             ^^^^^^^ source.metamodelica storage.type
-algorithm
-  () := match oi
-    case SOME(i) then ();
-//       ^^^^ source.metamodelica entity.name.type
-    case NONE() then ();
-//       ^^^^ source.metamodelica entity.name.type
-  end match;
-end f;
+opt := if cond then SOME(i) else NONE();
+//                  ^^^^ source.metamodelica entity.name.type
+//                          ^^^^ source.metamodelica keyword.control
+//                               ^^^^ source.metamodelica entity.name.type


### PR DESCRIPTION
- Only match `SOME`, not what's inside.
- Make test smaller