### PR TITLE
Solve polymorphic/comparison ambiguity

### DIFF
--- a/syntaxes/metamodelica.tmGrammar.yaml
+++ b/syntaxes/metamodelica.tmGrammar.yaml
@@ -43,7 +43,7 @@ patterns:
     name: storage.type
 
   ## Polymorphic types
-  - begin: \b(list|tuple|array|Option)\s*<
+  - begin: \b(list|tuple|array|Option)<
     end: '>'
     beginCaptures:
       1:
@@ -51,7 +51,7 @@ patterns:
     patterns:
       - include: '#polymorphic_type'
 
-  - begin: \b(\w+)\s*<
+  - begin: \b(\w+)<
     end : '>'
     beginCaptures:
       1:
@@ -171,7 +171,7 @@ repository:
           - include: '#polymorphic_type'
       - match: \b(Real|Integer|Boolean|String|enumeration|type)\b
         name: storage.type
-      - match: \b([\w\.]+)\b
+      - match: \b(\w+)\b
         name: entity.name.type
 
 scopeName: source.metamodelica

--- a/test/metamodelica/FunctionDoc.test.mo
+++ b/test/metamodelica/FunctionDoc.test.mo
@@ -11,7 +11,8 @@ public function foo
   output Option<SimCode.Awesome> awesome;
 //^^^^^^ source.metamodelica keyword.control
 //       ^^^^^^ source.metamodelica storage.type
-//              ^^^^^^^^^^^^^^^ source.metamodelica entity.name.type
+//              ^^^^^^^ source.metamodelica entity.name.type
+//                      ^^^^^^^ source.metamodelica entity.name.type
 // [...]
 end foo;
 

--- a/test/metamodelica/Types.test.mo
+++ b/test/metamodelica/Types.test.mo
@@ -29,3 +29,8 @@ type TL = UnorderedMap<Key, Value>;
 //        ^^^^^^^^^^^^ source.metamodelica entity.name.type
 //                     ^^^ source.metamodelica entity.name.type
 //                          ^^^^^ source.metamodelica entity.name.type
+
+x < 1 and x > 0;
+//^ keyword.operator.comparison
+//    ^^^ keyword.control
+//          ^ keyword.operator.comparison


### PR DESCRIPTION
Workaround is to have no space for polymorphic and space for comparisons. This is consistent with usual formatting in omc.