### PR TITLE
Fix nested block comments breaking Susan syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ languages to Visual Studio Code:
 *Susan template language used by OpenModelica:*
 ![Susan](./images/susan-template-example.png)
 
-*OpenModelica scripting language used by OpenModelica's *.mos files:*
+*OpenModelica scripting language used by OpenModelica's \*.mos files:*
 ![OpenModelica Scripting](./images/openmodelica-scripting-example.png)
 
 ### Snippets

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
   "scripts": {
     "prebuild": "sh yaml2json.sh",
     "build": "vsce package",
-    "test": "node --test test/detectLanguage.test.js && vscode-tmgrammar-test test/**/*.test.mo test/**/*.test.bmo"
+    "test": "node --test test/detectLanguage.test.js && vscode-tmgrammar-test test/**/*.test.mo test/**/*.test.bmo test/**/*.test.tpl"
   },
   "devDependencies": {
     "@vscode/vsce": "^3.7.1",

--- a/syntaxes/susan.tmGrammar.yaml
+++ b/syntaxes/susan.tmGrammar.yaml
@@ -96,11 +96,16 @@ patterns:
 repository:
   comments:
     patterns:
-      - begin: /\*
-        end: \*/
-        name: comment.block
+      - include: '#block-comment'
       - match: (//).*$\n?
         name: comment.line
+
+  block-comment:
+    begin: /\*
+    end: \*/
+    name: comment.block
+    patterns:
+      - include: '#block-comment'
 
   types:
     patterns:

--- a/test/susan/Comments.test.tpl
+++ b/test/susan/Comments.test.tpl
@@ -1,0 +1,21 @@
+// SYNTAX TEST "source.susan" "Susan block comments"
+
+/*
+//<-- source.susan comment.block
+/* inner */
+//<-- source.susan comment.block
+still in outer comment
+//<--- source.susan comment.block
+*/
+//<-- source.susan comment.block
+end daeExpCast;
+//<--- source.susan keyword
+//  ^^^^^^^^^^ source.susan entity.name.function
+
+/* comment one */
+//<-- source.susan comment.block
+end foo;
+//<--- source.susan keyword
+//  ^^^ source.susan entity.name.function
+/* comment two */
+//<-- source.susan comment.block


### PR DESCRIPTION
## Issue 

Fixes #124.

## Changes

Restructure the Susan block-comment grammar rule to be self-referential, so that /* ... /* inner */ ... */ is handled correctly. Previously, the inner */ terminated the outer comment, causing everything after it to lose its highlighting.

Also add test/susan/Comments.test.tpl covering nested comments and two serial comments with code in between, and extend the npm test script to include *.test.tpl files.