### PR TITLE
Fix enumeration block not closing

### DIFF
--- a/syntaxes/metamodelica.tmGrammar.yaml
+++ b/syntaxes/metamodelica.tmGrammar.yaml
@@ -22,7 +22,7 @@ patterns:
     beginCaptures:
       1:
         name: storage.type.enumeration
-    end: \)\s*("([^"]|\\")*(?<!\\)")?\s*;
+    end: \)\s*("([^"]|\\")*(?<!\\)")?(?:\s*;)?
     endCaptures:
       1:
         name: comment.line

--- a/test/metamodelica/Enumeration.test.mo
+++ b/test/metamodelica/Enumeration.test.mo
@@ -33,3 +33,28 @@ type FavouriteMinionFood = enumeration(BANANA "A banana", APPLE "An apple", GELA
 //                                                                                                                          ^^^^^^ source.metamodelica variable.other.enummember
 //                                                                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.metamodelica comment.line
 //                                                                                                                                                                                            ^^^^^^^^^^^^^^^^^^^ source.metamodelica comment.line
+
+// Issue #78: enumeration with closing paren on same line as opening paren
+
+// Baseline: closing paren and semicolon on same line
+type Issue78_A = enumeration();
+//<--- source.metamodelica storage.type
+//   ^^^^^^^^^ source.metamodelica entity.name.type
+//             ^ source.metamodelica keyword.operator.assignment
+//               ^^^^^^^^^^^ source.metamodelica storage.type.enumeration
+
+// Closing paren on same line, semicolon on next line.
+// Subsequent code must not be inside the (now properly closed) enumeration block.
+type Issue78_B = enumeration()
+//               ^^^^^^^^^^^ source.metamodelica storage.type.enumeration
+;
+type Issue78_C = enumeration();
+//<--- source.metamodelica storage.type
+
+// Docstring and semicolon on next line.
+// Subsequent code must not be inside the (now properly closed) enumeration block.
+type Issue78_D = enumeration()
+//               ^^^^^^^^^^^ source.metamodelica storage.type.enumeration
+"docstring";
+type Issue78_E = enumeration();
+//<--- source.metamodelica storage.type


### PR DESCRIPTION
## Issue

Fixes #78.

## Changes

Fix enumeration block not closing when closing parent and semicolon are on separate lines.

The end pattern for the MetaModelica enumeration begin/end block required the closing `)`, optional doc string, and `;` to all appear on the same line. When code like `enumeration()` appeared with `;` or `"doc";` on the next line, the block never closed and corrupted highlighting for all subsequent declarations.

Fix: make the trailing semicolon optional (`(?:\s*;)?`) so the block closes at `)` regardless of where the semicolon appears.

Tests added for: `)` and `;` on separate lines, doc string + `;` on next line, and a baseline same-line case.